### PR TITLE
Phase 1 master bringup launch file

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,10 +22,38 @@ To get started with the ROS2 Racer, follow these steps:
     source install/setup.bash
     ```
 5. Launch the ROS2 Racer:
-    Coming soon!
-    <!--```bash
-    ros2 launch ros2_racer racer.launch.py
-    ```-->
+    ```bash
+    ros2 launch racer_bringup master_bringup.launch.py
+    ```
+
+## Phase 1 Bringup
+
+The `racer_bringup` package provides a single launch file that starts the entire Phase 1 hardware and infrastructure stack:
+
+```bash
+ros2 launch racer_bringup master_bringup.launch.py
+```
+
+This starts the following nodes in order:
+
+| Node | Package | Topics |
+|------|---------|--------|
+| `rplidar_node` | `rplidar_ros` | publishes `/scan` |
+| `rs_stream_node` | `rs_stream` | publishes `/camera/color/image_raw` |
+| `rover_node` | `robo_rover` | publishes `/imu/gyro`, `/imu/accel`, `/rover/armed`; subscribes `/cmd_vel` |
+| *(E-Stop — not yet implemented)* | — | — |
+| `telemetry_node` | `telemetry` | publishes `/telemetry/racer` at 10 Hz |
+| rosbridge WebSocket | `rosbridge_server` | WebSocket on port 9090 |
+
+Hardware ports can be overridden at launch time:
+
+```bash
+ros2 launch racer_bringup master_bringup.launch.py \
+    lidar_port:=/dev/ttyUSB0 \
+    rover_port:=/dev/ttyACM1
+```
+
+Once all nodes are up the car is fully ready to receive commands (`/cmd_vel`) and broadcast telemetry to the dashboard.
 
 ## Telemetry Dashboard
 
@@ -37,7 +65,4 @@ npm install
 npm run dev
 ```
 
-Requires `rosbridge_server` running on the car:
-```bash
-ros2 launch rosbridge_server rosbridge_websocket_launch.xml
-```
+`rosbridge_server` is started automatically by `master_bringup.launch.py`. No separate terminal needed.

--- a/src/racer_bringup/launch/master_bringup.launch.py
+++ b/src/racer_bringup/launch/master_bringup.launch.py
@@ -24,7 +24,7 @@ import os
 from ament_index_python.packages import get_package_share_directory
 from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument, IncludeLaunchDescription, LogInfo
-from launch.launch_description_sources import XMLLaunchDescriptionSource
+from launch.launch_description_sources import AnyLaunchDescriptionSource
 from launch.substitutions import LaunchConfiguration
 from launch_ros.actions import Node
 
@@ -123,7 +123,7 @@ def generate_launch_description():
 
     # ── 6. rosbridge WebSocket server ────────────────────────────────────────
     rosbridge_launch = IncludeLaunchDescription(
-        XMLLaunchDescriptionSource(
+        AnyLaunchDescriptionSource(
             os.path.join(
                 get_package_share_directory('rosbridge_server'),
                 'launch',

--- a/src/racer_bringup/launch/master_bringup.launch.py
+++ b/src/racer_bringup/launch/master_bringup.launch.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+"""
+Phase 1 master bringup launch file.
+
+Brings up the full hardware and infrastructure stack in a single command:
+  1. LIDAR        (rplidar_ros  → /scan)
+  2. RealSense    (rs_stream    → /camera/color/image_raw)
+  3. Hardware Bridge (robo_rover → /imu/*, /rover/armed, subscribes /cmd_vel)
+  4. E-Stop       (TODO: not yet implemented)
+  5. Telemetry    (telemetry    → /telemetry/racer)
+  6. rosbridge    (rosbridge_server WebSocket on port 9090)
+
+Usage:
+    ros2 launch racer_bringup master_bringup.launch.py
+
+Override hardware ports as needed:
+    ros2 launch racer_bringup master_bringup.launch.py \
+        lidar_port:=/dev/ttyUSB0 \
+        rover_port:=/dev/ttyACM1
+"""
+
+import os
+
+from ament_index_python.packages import get_package_share_directory
+from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument, IncludeLaunchDescription, LogInfo
+from launch.launch_description_sources import XMLLaunchDescriptionSource
+from launch.substitutions import LaunchConfiguration
+from launch_ros.actions import Node
+
+
+def generate_launch_description():
+    # ── Launch arguments ────────────────────────────────────────────────────
+    lidar_port_arg = DeclareLaunchArgument(
+        'lidar_port',
+        default_value='/dev/ttyUSB0',
+        description='USB serial port for the RPLiDAR',
+    )
+    lidar_baudrate_arg = DeclareLaunchArgument(
+        'lidar_baudrate',
+        default_value='115200',
+        description='Baud rate for the RPLiDAR serial connection',
+    )
+    rover_port_arg = DeclareLaunchArgument(
+        'rover_port',
+        default_value='/dev/ttyACM1',
+        description='MAVLink serial port for the ArduPilot rover (Pixhawk)',
+    )
+    rover_baudrate_arg = DeclareLaunchArgument(
+        'rover_baudrate',
+        default_value='115200',
+        description='Baud rate for the rover MAVLink connection',
+    )
+    telemetry_rate_arg = DeclareLaunchArgument(
+        'telemetry_rate',
+        default_value='10.0',
+        description='Telemetry publish rate in Hz',
+    )
+    image_quality_arg = DeclareLaunchArgument(
+        'image_quality',
+        default_value='50',
+        description='JPEG compression quality for camera frames (0-100)',
+    )
+
+    lidar_port = LaunchConfiguration('lidar_port')
+    lidar_baudrate = LaunchConfiguration('lidar_baudrate')
+    rover_port = LaunchConfiguration('rover_port')
+    rover_baudrate = LaunchConfiguration('rover_baudrate')
+
+    # ── 1. LIDAR ─────────────────────────────────────────────────────────────
+    lidar_node = Node(
+        package='rplidar_ros',
+        executable='rplidar_node',
+        name='rplidar_node',
+        parameters=[{
+            'channel_type': 'serial',
+            'serial_port': lidar_port,
+            'serial_baudrate': lidar_baudrate,
+            'frame_id': 'laser',
+            'inverted': False,
+            'angle_compensate': True,
+        }],
+        output='screen',
+    )
+
+    # ── 2. RealSense ─────────────────────────────────────────────────────────
+    realsense_node = Node(
+        package='rs_stream',
+        executable='rs_stream_node',
+        name='rs_stream_node',
+        output='screen',
+    )
+
+    # ── 3. Hardware Bridge ───────────────────────────────────────────────────
+    rover_node = Node(
+        executable='python3',
+        arguments=['-m', 'robo_rover.rover_node'],
+        name='rover_node',
+        output='screen',
+        emulate_tty=True,
+        parameters=[{
+            'connection_string': rover_port,
+            'baud_rate': rover_baudrate,
+            'control_frequency': 20.0,
+            'imu_frequency': 20.0,
+        }],
+    )
+
+    # ── 4. E-Stop ────────────────────────────────────────────────────────────
+    # TODO: E-Stop node — not yet implemented
+
+    # ── 5. Telemetry Aggregator ──────────────────────────────────────────────
+    telemetry_node = Node(
+        package='telemetry',
+        executable='telemetry_node',
+        name='telemetry_node',
+        parameters=[{
+            'publish_rate': LaunchConfiguration('telemetry_rate'),
+            'image_quality': LaunchConfiguration('image_quality'),
+        }],
+        output='screen',
+    )
+
+    # ── 6. rosbridge WebSocket server ────────────────────────────────────────
+    rosbridge_launch = IncludeLaunchDescription(
+        XMLLaunchDescriptionSource(
+            os.path.join(
+                get_package_share_directory('rosbridge_server'),
+                'launch',
+                'rosbridge_websocket_launch.xml',
+            )
+        )
+    )
+
+    return LaunchDescription([
+        # Arguments
+        lidar_port_arg,
+        lidar_baudrate_arg,
+        rover_port_arg,
+        rover_baudrate_arg,
+        telemetry_rate_arg,
+        image_quality_arg,
+
+        # Startup banner
+        LogInfo(msg='[racer_bringup] Starting Phase 1 hardware and infrastructure stack...'),
+
+        # Nodes (sensors first, bridge, then aggregators/infrastructure)
+        lidar_node,
+        realsense_node,
+        rover_node,
+        telemetry_node,
+        rosbridge_launch,
+
+        LogInfo(msg='[racer_bringup] All nodes launched. Car is ready.'),
+    ])

--- a/src/racer_bringup/package.xml
+++ b/src/racer_bringup/package.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>racer_bringup</name>
+  <version>0.0.0</version>
+  <description>Master bringup launch file for the Phase 1 ROS2 Racer hardware and infrastructure stack</description>
+  <maintainer email="rane.gray@colorado.edu">student</maintainer>
+  <license>Apache-2.0</license>
+
+  <exec_depend>rplidar_ros</exec_depend>
+  <exec_depend>rs_stream</exec_depend>
+  <exec_depend>robo_rover</exec_depend>
+  <exec_depend>telemetry</exec_depend>
+  <exec_depend>rosbridge_server</exec_depend>
+
+  <test_depend>ament_copyright</test_depend>
+  <test_depend>ament_flake8</test_depend>
+  <test_depend>ament_pep257</test_depend>
+  <test_depend>python3-pytest</test_depend>
+
+  <export>
+    <build_type>ament_python</build_type>
+  </export>
+</package>

--- a/src/racer_bringup/setup.cfg
+++ b/src/racer_bringup/setup.cfg
@@ -1,0 +1,4 @@
+[develop]
+script_dir=$base/lib/racer_bringup
+[install]
+install_scripts=$base/lib/racer_bringup

--- a/src/racer_bringup/setup.py
+++ b/src/racer_bringup/setup.py
@@ -1,0 +1,26 @@
+from setuptools import setup
+from glob import glob
+import os
+
+package_name = 'racer_bringup'
+
+setup(
+    name=package_name,
+    version='0.0.0',
+    packages=[],
+    data_files=[
+        ('share/ament_index/resource_index/packages', ['resource/' + package_name]),
+        ('share/' + package_name, ['package.xml']),
+        (os.path.join('share', package_name, 'launch'), glob('launch/*.py')),
+    ],
+    install_requires=['setuptools'],
+    zip_safe=True,
+    maintainer='student',
+    maintainer_email='rane.gray@colorado.edu',
+    description='Master bringup launch file for the Phase 1 ROS2 Racer hardware and infrastructure stack',
+    license='Apache-2.0',
+    extras_require={'test': ['pytest']},
+    entry_points={
+        'console_scripts': [],
+    },
+)

--- a/src/robo_rover/robo_rover/rover_node.py
+++ b/src/robo_rover/robo_rover/rover_node.py
@@ -352,7 +352,10 @@ def main(args=None):
     finally:
         if 'node' in locals():
             node.destroy_node()
-        rclpy.shutdown()
+        try:
+            rclpy.shutdown()
+        except Exception:
+            pass
 
 
 if __name__ == '__main__':

--- a/src/rs_stream/rs_stream/rs_stream_node.py
+++ b/src/rs_stream/rs_stream/rs_stream_node.py
@@ -59,8 +59,8 @@ class RealsenseColorPublisher(Node):
             self._frame_count += 1
             if self._frame_count % self._heartbeat_interval == 0:
                 self.get_logger().info(f'RealSense streaming OK ({self._frame_count} frames published)')
-        except Exception as e:
-            self.get_logger().warn(f'Frame skip: {e}')
+        except Exception:
+            pass  # transient frame drop; heartbeat will surface if camera goes silent
 
     def destroy_node(self):
         self.timer.cancel()

--- a/src/rs_stream/rs_stream/rs_stream_node.py
+++ b/src/rs_stream/rs_stream/rs_stream_node.py
@@ -52,7 +52,6 @@ class RealsenseColorPublisher(Node):
             msg = self.bridge.cv2_to_imgmsg(img, encoding='bgr8')
             msg.header.stamp = self.get_clock().now().to_msg()
             msg.header.frame_id = 'camera_color_optical_frame'
-            self.get_logger().info("Published frame successfully.")
             self.pub.publish(msg)
         except Exception as e:
             self.get_logger().warn(f'Frame skip: {e}')

--- a/src/rs_stream/rs_stream/rs_stream_node.py
+++ b/src/rs_stream/rs_stream/rs_stream_node.py
@@ -41,6 +41,9 @@ class RealsenseColorPublisher(Node):
 
         # timer at ~fps
         self.timer = self.create_timer(1.0 / fps, self.capture_and_publish)
+        self._fps = fps
+        self._frame_count = 0
+        self._heartbeat_interval = fps * 10  # log once every 10 seconds
 
     def capture_and_publish(self):
         try:
@@ -53,6 +56,9 @@ class RealsenseColorPublisher(Node):
             msg.header.stamp = self.get_clock().now().to_msg()
             msg.header.frame_id = 'camera_color_optical_frame'
             self.pub.publish(msg)
+            self._frame_count += 1
+            if self._frame_count % self._heartbeat_interval == 0:
+                self.get_logger().info(f'RealSense streaming OK ({self._frame_count} frames published)')
         except Exception as e:
             self.get_logger().warn(f'Frame skip: {e}')
 
@@ -73,7 +79,10 @@ def main():
         pass
     finally:
         node.destroy_node()
-        rclpy.shutdown()
+        try:
+            rclpy.shutdown()
+        except Exception:
+            pass
 
 if __name__ == '__main__':
     main()

--- a/src/telemetry/telemetry/telemetry_node.py
+++ b/src/telemetry/telemetry/telemetry_node.py
@@ -175,7 +175,10 @@ def main(args=None):
         pass
     finally:
         node.destroy_node()
-        rclpy.shutdown()
+        try:
+            rclpy.shutdown()
+        except Exception:
+            pass
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary

- Adds `racer_bringup` package with `master_bringup.launch.py` — a single command that starts the full Phase 1 hardware and infrastructure stack (LIDAR, RealSense, hardware bridge, telemetry aggregator, rosbridge WebSocket)
- Updates README with the launch command, a node table, and port override instructions
- Guards `rclpy.shutdown()` in `rover_node`, `telemetry_node`, and `rs_stream_node` so Ctrl+C produces clean exits instead of tracebacks
- Cleans up RealSense logging: removes per-frame success spam, suppresses transient frame-drop warnings, adds a 10-second heartbeat instead

## Usage

```bash
ros2 launch racer_bringup master_bringup.launch.py

# override hardware ports if needed
ros2 launch racer_bringup master_bringup.launch.py     lidar_port:=/dev/ttyUSB0     rover_port:=/dev/ttyACM1
```

## Test plan

- [x] `colcon build` completes without errors
- [x] `ros2 launch racer_bringup master_bringup.launch.py` starts all nodes
- [x] LIDAR, RealSense, telemetry, and rosbridge all appear in `ros2 node list`
- [x] Dashboard receives telemetry over WebSocket
- [x] Ctrl+C produces clean shutdown with no tracebacks

🤖 Generated with [Claude Code](https://claude.com/claude-code)